### PR TITLE
Added `request` feature 

### DIFF
--- a/syqlorix/__init__.py
+++ b/syqlorix/__init__.py
@@ -4,6 +4,7 @@ from .css import css
 from .components import component
 from .components_lib import SimpleAlert, ImageGallery
 from .loader import load_component
+from .request import request
 
 __version__ = "0.0.3.3"
 
@@ -16,4 +17,5 @@ __all__ = [
     "SimpleAlert",
     "ImageGallery",
     "load_component",
+    "request",
 ]

--- a/syqlorix/devserver.py
+++ b/syqlorix/devserver.py
@@ -8,6 +8,7 @@ import mimetypes
 from typing import Callable, Dict, Union, Any
 
 from .page import Page
+from .request import set_request, request, Request, clear_request
 
 class Route:
     def __init__(self, path: str = "/"):
@@ -80,7 +81,9 @@ class SyqlorixDevServerHandler(http.server.BaseHTTPRequestHandler):
             page_source = self.routes_map[path]
             try:
                 if callable(page_source):
+                    set_request(path=self.path)
                     page_source = page_source()
+                    clear_request()
                 if isinstance(page_source, Page):
                     html_content = page_source.render()
                 elif isinstance(page_source, str):

--- a/syqlorix/request.py
+++ b/syqlorix/request.py
@@ -1,0 +1,33 @@
+import threading
+from functools import wraps
+
+# Create a thread-local storage
+_request_ctx = threading.local()
+
+class RequestProxy:
+    def __getattr__(self, name):
+        return getattr(_request_ctx.request, name)
+
+    def __setattr__(self, name, value):
+        if name == '_request_ctx':
+            super().__setattr__(name, value)
+        else:
+            object.__setattr__(_request_ctx.request, name, value)
+
+
+class Request:
+    def __init__(self, path: str, **kwargs):
+        self.path = path
+        for k,v in kwargs.items():
+            object.__setattr__(self, k, v)
+
+request = RequestProxy()
+
+def set_request(**kwargs):
+    clear_request()
+    _request_ctx.request = Request(**kwargs)
+
+def clear_request():
+    if hasattr(_request_ctx, 'request'):
+        del _request_ctx.request
+


### PR DESCRIPTION
## Description

Added request feature
```py
from syqlorix import start_dev_server as serve_pages_dev, Route, request

base=Route("/")

@base.route("/")
def hi():
  return request.path
  
serve_pages_dev(base)
```

Note: currently, the `Request` object has only one attribute (`Request.path`) as I don't know how to find other ones (effectively) yet!

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This has been tested just by opening the webpage.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
